### PR TITLE
Add ° symbol to fix temperature sensors when exposed to HomeKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ sensor:
           {% set panel = states('sensor.pool_panel') %}
           {% if panel is search('(Pool|Spa) Temp') %} {{ panel | regex_findall_index(' Temp +(\d+)') }} {% else %} {{ states('sensor.pool_temperature') }} {% endif %}
         device_class: temperature
-        unit_of_measurement: "F"
+        unit_of_measurement: "°F"
       air_temperature:
         friendly_name: "Air temperature"
         value_template: >-
           {% set panel = states('sensor.pool_panel') %}
           {% if panel is search('Air Temp') %} {{ panel | regex_findall_index('Air Temp +(\d+)') }} {% else %} {{ states('sensor.air_temperature') }} {% endif %}
         device_class: temperature
-        unit_of_measurement: "F"
+        unit_of_measurement: "°F"
 switch:
   - platform: template
     switches:


### PR DESCRIPTION
The unit of measurement needs a ° symbol (HASS sure is picky) to work properly when exposed to HomeKit